### PR TITLE
課題2：出品時のフォームでのhidden_fieldを削除し、itemのrouteのネストさせる

### DIFF
--- a/app/controllers/public/sell_items_controller.rb
+++ b/app/controllers/public/sell_items_controller.rb
@@ -51,11 +51,12 @@ class Public::SellItemsController < ApplicationController
   def create
     @sell_item = SellItem.new(sell_item_params)
     @sell_item.seller_id = current_user.id
-
+    
+    item = Item.find(params[:item_id])
+    @sell_item.item_id = item.id
     if @sell_item.save
-      @item = @sell_item.item
-      @item.item_status = "on_sell"
-      @item.save
+      item.item_status = "on_sell"
+      item.save
       flash[:success] = "出品が完了しました。"
       redirect_to sell_items_path
     else

--- a/app/views/public/sell_items/new.html.erb
+++ b/app/views/public/sell_items/new.html.erb
@@ -16,7 +16,7 @@
 
   <div class ="row justify-content-center">
     <div class="col-lg-6 col-md-10 col-sm-10 item-new-fields">
-      <%= form_with model: @sell_item, local:true do |f| %>
+      <%= form_with model: @sell_item, url: item_sell_item_path(@item), local:true do |f| %>
 
         <div class="field py-3">
           <%= f.label :アイテム画像 %><br />
@@ -92,10 +92,6 @@
             <%= f.radio_button :delivery_days, :days4_7 %>
             <%= f.label '4日~7日で発送' %>
           </div>
-        </div>
-
-        <div class="field py-3">
-          <%= f.hidden_field :item_id, value: @item.id %>
         </div>
 
         <div class="new-item-btn py-3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,7 @@ Rails.application.routes.draw do
   get 'sell_items/myitems_by_order', to: 'public/sell_items#myitems_by_order', as: 'myitems_by_order'
   get 'sell_items/myitems_by_order_status', to: 'public/sell_items#myitems_by_order_status', as: 'myitems_by_order_status'
   post 'sell_items/:id/force_to_update', to: 'public/sell_items#force_to_update',as: 'force_to_update'
-  resources :sell_items, module: :public do
+  resources :sell_items, module: :public, except: [:create] do
     resource :likes, only: [:create, :destroy]
     resources :comments, only: [:create, :destroy]
     collection do
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
   resources :items, module: :public, except: [:destroy] do
     patch 'status_discarded'
     get 'sell_item/new', to: 'sell_items#new'
+    post 'sell_item', to: 'sell_items#create'
     member do
       patch 'wear_today_update'
     end


### PR DESCRIPTION
## Issue
#2 

## 課題２の概要
■ 出品item作成周りリファクタ
出品時のフォームで、hiddenでitem_idを渡していますが、こちらを削除しても動くようにリファクタしてください。

## 変更概要
出品時フォームの、item_idを渡しているhidden_fieldを削除し、sell_itemのcreateルーティングにitem_idを付与し、findメソッドを使用してitem_idを取得するように変更しました。
そのために、変更した部分を以下の変更点としてまとめています。

## 変更点
✅　出品時フォームのitem_idを渡しているhidden_fieldを削除
✅　sell_itemのcreateルーティングを削除
✅　Itemのルーティングにsell_itemをネストさせ以下のルーティングを作成
✅　出品時formのデータ送信先(URL)にネストさせたルーティングを設定
✅　sell_itemのcreateアクションで、findメソッドを使用しURLよりitem_idを取得

```
POST   /items/:item_id/sell_item      public/sell_items#create
```
