### PR TITLE
課題１：商品購入におけるitemとsell_itemの登録処理が失敗した際も、カード決済は実行される不具合の修正

### DIFF
--- a/app/controllers/public/sell_items_controller.rb
+++ b/app/controllers/public/sell_items_controller.rb
@@ -109,24 +109,28 @@ class Public::SellItemsController < ApplicationController
       redirect_back(fallback_location: root_path)
 
     elsif cookies[:payment_method].present?
-
-      pay if cookies[:payment_method] == "credit_card"
-
-      @sell_item.update(buy_item_params)
-      cookies.delete :payment_method
       item = @sell_item.item
       item.item_status = "discarded"
-      item.save
-      # 通知機能の記述
-      @sell_item.create_notification_buy!(current_user)
-      NotificationMailer.send_mail(@sell_item.buyer, @sell_item).deliver_now
-      NotificationMailer.seller_send_mail(@sell_item.seller, @sell_item).deliver_now
-      redirect_to sell_items_order_complete_path(params[:id])
+
+      if @sell_item.update(buy_item_params) && item.save
+          pay if cookies[:payment_method] == "credit_card"
+          cookies.delete :payment_method
+          # 通知機能の記述
+          @sell_item.create_notification_buy!(current_user)
+          NotificationMailer.send_mail(@sell_item.buyer, @sell_item).deliver_now
+          NotificationMailer.seller_send_mail(@sell_item.seller, @sell_item).deliver_now
+          redirect_to sell_items_order_complete_path(params[:id])
+      else
+        cookies.delete :payment_method
+        redirect_to sell_item_path(@sell_item), alert: '購入ができませんでした。最初からやり直してください。'
+      end
+      
     else
       redirect_to root_path, notice: '不正な遷移は許可されていません'
     end
 
   end
+
 
   def order_complete
     @sell_item = SellItem.find(params[:id])


### PR DESCRIPTION
## Issue
#4 

## 課題１の概要
■ 課題1 データ不整合をなくす
支払いが成功した後に @sell_item.update(buy_item_params) やitem.save が何らかの理由で失敗してfalseが返っても特にエラー無く処理が進んでしまいます。その場合、カード決済は完了しているのにこのminimum上では購入ができていない、という状態になる不具合を改善してください。

## 変更概要
payアクション（カード決済）と、@sell_item.update(buy_item_params) 、item.save がそれぞれ独立した形で、設計していました。そのため、カード決済は完了しているがアプリ上では購入できていないという不具合が発生していました。

そこで、@sell_item.update(buy_item_params) とitem.saveの両方 が正常に処理された時のみ、payアクション（カード決済）を行うように変更しました。

変更した部分を以下の変更点としてまとめています。

## 変更点
✅　sell_item.updateとitem.saveの成功時、失敗時の処理を、if文を使用し条件分岐させる
　　(if @sell_item.update(buy_item_params) && item.save)
✅　if文がtrueの時にのみ、payアクションを行う(if文がtrue時の処理にpayアクションを移動)
✅　正常にsell_item.updateまたはitem.saveが行われなかった場合、商品詳細画面へ遷移させる。
　  （この際、cookiesも削除し、flashメッセージにて、最初からやり直すことを促す）

```
if @sell_item.update(buy_item_params) && item.save
        pay if cookies[:payment_method] == "credit_card"
        cookies.delete :payment_method
        @sell_item.create_notification_buy!(current_user)
        NotificationMailer.send_mail(@sell_item.buyer, @sell_item).deliver_now
        NotificationMailer.seller_send_mail(@sell_item.seller, @sell_item).deliver_now
        redirect_to sell_items_order_complete_path(params[:id])
else
        cookies.delete :payment_method
        redirect_to sell_item_path(@sell_item), alert: '購入ができませんでした。最初からやり直してください。'
end
```
